### PR TITLE
Fix gsad typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Simply run:
 docker run -d -p 443:443 -p 9390:9390 -p 9391:9391 --name openvas mikesplain/openvas
 ```
 
-This will grab the container from the docker registry and start it up.  Openvas startup can take some time (4-5 minutes while NVT's are scanned and databases rebuilt), so be patient.  Once you see a `gasd` process in the top command below, the web ui is good to go.  Goto `https://<machinename>`
+This will grab the container from the docker registry and start it up.  Openvas startup can take some time (4-5 minutes while NVT's are scanned and databases rebuilt), so be patient.  Once you see a `gsad` process in the top command below, the web ui is good to go.  Goto `https://<machinename>`
 
 ```
 Username: admin


### PR DESCRIPTION
Should be `gsad` not `gasd`. Might lead noobs astray.